### PR TITLE
Introduce customClasspath() to fulfill prerequisite for Gradle plugin

### DIFF
--- a/check/src/main/scala/de/schauderhaft/degraph/check/Check.scala
+++ b/check/src/main/scala/de/schauderhaft/degraph/check/Check.scala
@@ -35,8 +35,15 @@ object Check {
    * Note in a typical maven like setup it will also include the test classes as well as all libraries, which might not be desirable.
    * Manipulate the configuration to only contain the classpath elements required or use include and exclude filters for limiting the analyzed classes.
    */
-  val classpath = ConstraintBuilder(new Configuration(
-    classpath = Option(System.getProperty("java.class.path")),
+  val classpath = customClasspath(System.getProperty("java.class.path"))
+
+  /**
+   * a Configuration object containing a custom classpath.
+   *
+   * Intended as a starting point for analyzing the application that is currently running.
+   */
+  def customClasspath(path: String): ConstraintBuilder = ConstraintBuilder(new Configuration(
+    classpath = Option(path),
     analyzer = Analyzer), "package")
 
   /**

--- a/check/src/main/scala/de/schauderhaft/degraph/check/JCheck.scala
+++ b/check/src/main/scala/de/schauderhaft/degraph/check/JCheck.scala
@@ -10,5 +10,7 @@ import de.schauderhaft.degraph.check.hamcrest.HamcrestWrapper
 object JCheck {
   def classpath = Check.classpath
 
+  def customClasspath(path: String) = Check.customClasspath(path)
+
   val violationFree = new HamcrestWrapper[ConstraintBuilder](Check.violationFree)
 }

--- a/check/src/test/java/de/schauderhaft/degraph/check/JavaCheckApiTest.java
+++ b/check/src/test/java/de/schauderhaft/degraph/check/JavaCheckApiTest.java
@@ -16,6 +16,12 @@ public class JavaCheckApiTest {
     public void canAccessClasspathConfigurationBuilder() {
         classpath();
     }
+    
+    @Test
+    public void canProvideCustomClasspath() {
+        customClasspath("foo:bar");
+    }
+
     @Test
     public void canAccessNoJars() {
         classpath().noJars();


### PR DESCRIPTION
I started writing a Gradle plugin for degraph and ran into the problem that `Check#classpath` is a constant. Therefore, once the `Check` class is loaded, it will not change its value. This makes it impossible to use a different classpath than `System.getProperty("java.class.path")`.
