### PR TITLE
Add source -> target to edge description

### DIFF
--- a/core/src/main/scala/de/schauderhaft/degraph/writer/Writer.scala
+++ b/core/src/main/scala/de/schauderhaft/degraph/writer/Writer.scala
@@ -127,6 +127,7 @@ class EdgeWriter(
 
     def apply(source: GNode, target: GNode) =
         <edge id={ id(source) + "::" + id(target) } source={ id(source) } target={ id(target) }>
+            <data key="d9">{ scala.xml.Unparsed("<![CDATA[%s]]>".format(s"${source.name} -> ${target.name}")) }</data>
             <data key="d10">
                 <y:PolyLineEdge>
                     <y:LineStyle color={ styler(source, target).colorHexString } type="line" width={ styler(source, target).widthString }/>


### PR DESCRIPTION
When an edge is selected in yED, then in the Properties View the flyover of the Data::Description field will show the edge source and destination. This is useful in very nested graphs to see the exact route of a dependency.